### PR TITLE
Database: Build path of internal database using script's directory

### DIFF
--- a/Datenbank.py
+++ b/Datenbank.py
@@ -7,6 +7,8 @@ from PyQt5 import QtWidgets
 from Wolke import Wolke
 import logging
 
+ZENTRALE_DATENBANK = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'datenbank.xml')
+
 class DatabaseException(Exception):
     pass
 
@@ -229,8 +231,8 @@ class Datenbank():
         self.freieFertigkeiten = {}
         self.removeList = []
 
-        if os.path.isfile('datenbank.xml'):
-            self.xmlLadenInternal('datenbank.xml', refDB=True)
+        if os.path.isfile(ZENTRALE_DATENBANK):
+            self.xmlLadenInternal(ZENTRALE_DATENBANK, refDB=True)
             self.loaded = True
 
         try:   

--- a/DatenbankEdit.py
+++ b/DatenbankEdit.py
@@ -445,8 +445,7 @@ class DatenbankEdit(object):
             elif result == 2:
                 return
 
-        refDatabaseFile = os.getcwd() + os.path.normpath("/datenbank.xml")
-        if spath == refDatabaseFile:
+        if spath == Datenbank.ZENTRALE_DATENBANK:
             infoBox = QtWidgets.QMessageBox()
             infoBox.setIcon(QtWidgets.QMessageBox.Information)
             infoBox.setText("Überschreiben der zentralen Datenbank verhindert!")
@@ -483,8 +482,7 @@ die datenbank.xml, aber bleiben bei Updates erhalten!")
             self.saveDatenbank()
             return
 
-        refDatabaseFile = os.getcwd() + os.path.normpath("/datenbank.xml")
-        if self.savepath == refDatabaseFile:
+        if self.savepath == Datenbank.ZENTRALE_DATENBANK:
             infoBox = QtWidgets.QMessageBox()
             infoBox.setIcon(QtWidgets.QMessageBox.Information)
             infoBox.setText("Überschreiben der zentralen Datenbank verhindert!")
@@ -524,8 +522,7 @@ die datenbank.xml, aber bleiben bei Updates erhalten!")
         if not spath:
             return
         spath = os.path.realpath(spath)
-        databaseFile = os.getcwd() + os.path.normpath("/datenbank.xml")
-        if spath == databaseFile:
+        if spath == Datenbank.ZENTRALE_DATENBANK:
             infoBox = QtWidgets.QMessageBox()
             infoBox.setIcon(QtWidgets.QMessageBox.Warning)
             infoBox.setText("Diese Funktion dient dem Laden einer Nutzer-Datenbank wie der 'database_user.xml'. Die zentrale Sephrasto-Datenbank 'database.xml' wird sowieso immer geladen!")


### PR DESCRIPTION
This changes the code to load the internal database from the directory of the
module loading the database instead of the current working directory. This
allows running Sephrasto from a different directory.

Fixes #46.