### PR TITLE
Theme Extension and .ini moved to os-dependant subfolder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ lxml~=4.7.1
 PyQt5==5.15.6
 pyyaml~=6.0
 requests~=2.26.0
+appdirs~=1.4.4

--- a/src/Sephrasto/PathHelper.py
+++ b/src/Sephrasto/PathHelper.py
@@ -1,0 +1,39 @@
+import appdirs
+import json
+import os
+from os import walk
+
+
+def getSettingsFolder():
+    return appdirs.user_config_dir(appname='Sephrasto', appauthor='Ilaris')
+
+
+def getDefaultUserFolder():
+    return os.path.join(os.path.expanduser('~'), 'Sephrasto')
+
+
+def createFolder(basePath):
+    if not os.path.isdir(basePath):
+        try:
+            # makedirs in case parent folder does not exist
+            os.makedirs(basePath)
+            return True
+        except:
+            return False
+
+
+def getThemes():
+    result = []
+    try:
+        themeFolder = os.path.join(getSettingsFolder(), "themes")
+        createFolder(themeFolder)
+        filenames = next(walk(themeFolder), (None, None, []))[2]
+        themes = [x for x in filenames if x.endswith(".json")]
+        for path in themes:
+            file = open(os.path.join(themeFolder, path), )
+            theme = json.load(file)
+            if ('name' in theme):
+                result.append(theme)
+    except:
+        pass
+    return result

--- a/src/Sephrasto/Sephrasto.py
+++ b/src/Sephrasto/Sephrasto.py
@@ -28,6 +28,8 @@ from PyQt5.QtWidgets import QToolTip
 from Hilfsmethoden import Hilfsmethoden
 import platform
 
+import PathHelper
+
 loglevels = {0: logging.ERROR, 1: logging.WARNING, 2: logging.DEBUG}
 logging.basicConfig(filename="sephrasto.log", \
     level=loglevels[Wolke.Settings['Logging']], \
@@ -406,6 +408,32 @@ class MainWindowWrapper(object):
             Wolke.HeadingColor = "#000000"
             Wolke.BorderColor = "rgba(0,0,0,0.2)"
             self.buildStylesheet("#dcc484", "#f6efe2")
+        else:
+            try:
+                for pal in PathHelper.getThemes():
+                    self.app.setStyle('fusion')
+                    palette = QPalette()
+
+                    if 'name' in pal and pal['name'] == style:
+                        for elem, col in pal["palette"]:
+                            palette.setColor(elem, QColor(col))
+
+                        if 'active' in pal:
+                            for elem, col in pal["active"]:
+                                palette.setColor(QPalette.Active, elem, QColor(col))
+
+                        if 'disabled' in pal:
+                            for elem, col in pal["disabled"]:
+                                palette.setColor(QPalette.Disabled, elem, QColor(col))
+
+                        self.app.setPalette(palette)
+                        QToolTip.setPalette(palette)
+                        Wolke.HeadingColor = pal["heading"]
+                        Wolke.BorderColor = pal["border"]
+                        self.buildStylesheet(pal["sheet"]["readonly"], pal["sheet"]["panel"], pal["sheet"]["button"])
+                        break
+            except:
+                pass
         
 if __name__ == "__main__":
     itm = MainWindowWrapper()


### PR DESCRIPTION
Ich habe mich ein wenig mehr mit Python beschäftigt und meinen vorherigen Pull Request nochmal überarbeitet. Ich kann bestätigen, dass der Code sowohl unter Windows als auch unter Linux funktioniert.

Die .ini Datei wird (noch) nicht automatisch verschoben, wenn es zuvor eine gab.

Nebenbei hab ich noch eine Erweiterung eingebaut, sodass man eigene Themes definieren kann. Ist nicht sehr nutzerfreundlich bisher, aber so muss ich den Code nicht groß verändern, wenn ich Sephrasto in lila haben möchte :)

![image](https://user-images.githubusercontent.com/4151368/186441385-8f44ccee-f71a-4a90-b9ff-62117b4f6a36.png)
