### PR TITLE
Fix Crash on invalid Theme

### DIFF
--- a/src/Sephrasto/Sephrasto.py
+++ b/src/Sephrasto/Sephrasto.py
@@ -318,6 +318,8 @@ class MainWindowWrapper(object):
                 Wolke.ReadonlyColor = theme["ReadonlyColor"]
             if "PanelColor" in theme:
                 Wolke.PanelColor = theme["PanelColor"]
+        else:
+            theme = ''
 
         # Create stylesheet
         standardFont = f"font-family: '{Wolke.Settings['Font']}'"


### PR DESCRIPTION
Wenn in der config ein ungültiges Theme (weil man die .ini gelöscht hat zb) angegeben hat, crasht die Anwendung. Der PR fixt diesen Fehler