### PR TITLE
Fix Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sephrasto
+# Sephrasto - Loirana Fork
 Ein Charaktergenerator für das DSA-Hausregelsystem Ilaris, erstellt von Aeolitus. So vollständig wie möglich. Eine Gebrauchsanweisung findest du, wenn du im Hauptfenster auf den Hilfe-Button clickst.
 
 ## Features

--- a/src/Sephrasto/Data/Themes/Loirana.ini
+++ b/src/Sephrasto/Data/Themes/Loirana.ini
@@ -1,0 +1,27 @@
+Style: fusion
+Palette:
+    Window: "#282a36"
+    WindowText: "#f8f8f2"
+    Base: "#282a36"
+    AlternateBase: "#6272a4"
+    ToolTipBase: "#282a36"
+    ToolTipText: "#f8f8f2"
+    Text: "#f8f8f2"
+    Button: "#44475a"
+    ButtonText: "#f8f8f2"
+    BrightText: "#f8f8f2"
+    Link: "#bd93f9"
+    Highlight: "#ffb86c"
+    HighlightedText: "#f8f8f2"
+Palette-Active:
+    Button: "#282a36"
+Palette-Disabled:
+    ButtonText: "#ff5555"
+    WindowText: "#ff5555"
+    Text: "#ff5555"
+    HighlightedText: "#ff5555"
+    Base: "#44475a"
+HeadingColor: "#bd93f9"
+BorderColor: "rgba(0,0,0,0.2)"
+ReadonlyColor: "#44475a"
+PanelColor: "#44475a"

--- a/src/Sephrasto/PathHelper.py
+++ b/src/Sephrasto/PathHelper.py
@@ -1,18 +1,10 @@
 import os
 import platform
 import unicodedata
+from PyQt5.QtCore import QStandardPaths
 
 def getSettingsFolder():
-    system = platform.system()
-    if system == 'Windows':
-        return getDefaultUserFolder()
-    elif system == 'Darwin':
-        path = os.path.expanduser('~/Library/Preferences/')
-        return os.path.join(path, "Sephrasto")
-    else:
-        path = os.getenv('XDG_CONFIG_HOME', os.path.expanduser("~/.config"))
-        return os.path.join(path, "Sephrasto")
-    return path
+    return os.path.join(QStandardPaths.writableLocation(QStandardPaths.ConfigLocation), 'Sephrasto')
 
 def getDefaultUserFolder():
     userFolder = os.path.expanduser('~')
@@ -24,7 +16,7 @@ def getDefaultUserFolder():
         buf= ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
         ctypes.windll.shell32.SHGetFolderPathW(None, CSIDL_PERSONAL, None, SHGFP_TYPE_CURRENT, buf)
         userFolder = buf.value or userFolder
-        return os.path.join(userFolder,'Sephrasto')
+        return os.path.join(userFolder, 'Sephrasto')
     elif system == 'Linux':
         if os.path.isdir(os.path.join(userFolder,'.sephrasto')):
             return os.path.join(userFolder,'.sephrasto') # allow users to rename the folder to a hidden folder
@@ -33,7 +25,7 @@ def getDefaultUserFolder():
     elif system == 'Darwin':
         return os.path.join(userFolder, 'Documents', 'Sephrasto') # the documents folder is language-independent on macos
     else:
-        return os.path.join(userFolder,'Sephrasto')
+        return os.path.join(userFolder, 'Sephrasto')
 
 def createFolder(basePath):
     if not os.path.isdir(basePath):

--- a/src/Sephrasto/Sephrasto.py
+++ b/src/Sephrasto/Sephrasto.py
@@ -337,10 +337,11 @@ QTreeView::item {{ margin-top: 4px; margin-bottom: 4px; }}
 .h3, QGroupBox {{ font-weight: bold; font-variant: small-caps; font-size: {Wolke.FontHeadingSizeL3}pt; {standardFont}; color: {Wolke.HeadingColor}; }}
 .h4 {{ font-weight: bold; }}
 .title {{ font-weight: bold; font-size: 16pt; {headingFont}; }}
-.icon {{ font-size: {min(Wolke.Settings['FontSize'], 12)}pt; font-family: 'Font Awesome 6 Free Solid';}}\n"""
+.icon {{ font-size: {min(Wolke.Settings['FontSize'], 12)}pt; font-family: 'Font Awesome 6 Free Solid'; font-weight: 'Solid'}}\n"""
 
         if 'CSS' in theme:
             css += theme['CSS']
+        css += ".icon { font-weight: 900; }\n"
         self.app.setStyleSheet(css)
         
 if __name__ == "__main__":


### PR DESCRIPTION
- Breaking change: Switched my PyQt (Qt 5) to PySide (Qt 6) for licensing reasons. Most plugins require an update. Major version bump to 3.0.0. Help: Added documentation for custom charsheets and theme. Character sheets: fixed wrong form field name for some talent page numbers; removed respective hack in PdfExporter Themes: Changed theme file support from json to yaml to stay consistent with Sephrastos other files. Added support for additional CSS to yaml theme files. Moved all Sephrasto themes into yaml files. Reduced user defined theme support to one and got rid of respective folder (one should suffice). Fonts: switched Crimson Pro from variable font to static font, looks better Weapons tab: now using icons in weapon detail label and added info about weapon improvements Inventory tab: fixed armor merging not being possible anymore because the add button transforms to a delete button. The delete buttons are separate now. Details tab: now hiding image and load/delete buttons if the character sheet doesnt support the image Design: reduced size of vorteil comment fields; changed some remaining icons to use css class instead of individually setting font etc. Disabled font hinting, doesn't look better and sometimes looks worse when enabled. Increased top/bottom margins for list and tree items Settings: add option to enable high dpi scaling (off by default, fusion still has some problems with it - low res plusminus icons, lowres messageboxicons, disappearing borders, lowres markdown images...); add option to move Charakterbögen folder; changed icon for resetting fonts to OS settings; now hiding "Plugins" groupbox if no plugins are installed; added many tooltips for the settings Misc: removed appdirs package
- Fixed crash if selected theme could not be found
- Replaced settingspath code with QStandardPaths
- Added Loirana Theme
- Added Font Weight in order to fix FontAwesome Icons
